### PR TITLE
Fix unused variable in landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@
 // import HaveWeMet from "@/components/HaveWeMet";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import Link from "@/components/link";
-import EncryptedTextSmooth from "@/components/EncryptedTextSmooth";
 import Paragraph from "@/components/paragraph";
 import { TetrisEasterEgg } from "@/components/tetris";
 


### PR DESCRIPTION
Remove unused import `EncryptedTextSmooth` to fix a linter error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d67cfcdf-901f-48df-9e33-c8ba361169f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d67cfcdf-901f-48df-9e33-c8ba361169f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

